### PR TITLE
Quit Button Enhancement

### DIFF
--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -737,6 +737,9 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
   cfgfile_dwrite_str (f, _T("absolute_mouse"), abspointers[p->input_tablet]);
 
   cfgfile_write (f, _T("key_for_menu"), _T("%d"), p->key_for_menu);
+	cfgfile_write (f, _T("key_for_quit"), _T("%d"), p->key_for_quit);
+  cfgfile_write (f, _T("button_for_menu"), _T("%d"), p->button_for_menu);
+	cfgfile_write (f, _T("button_for_quit"), _T("%d"), p->button_for_quit);
 
   cfgfile_write (f, _T("gfx_framerate"), _T("%d"), p->gfx_framerate);
   write_resolution (f, _T("gfx_width"), _T("gfx_height"), &p->gfx_size); /* compatibility with old versions */
@@ -1275,11 +1278,18 @@ static int cfgfile_parse_host (struct uae_prefs *p, TCHAR *option, TCHAR *value)
 	  || cfgfile_strval (option, value, _T("absolute_mouse"), &p->input_tablet, abspointers, 0))
     return 1;
 
-
-  if (cfgfile_intval (option, value, "key_for_menu", &p->key_for_menu, 1))
+  
+	if (cfgfile_intval (option, value, "key_for_menu", &p->key_for_menu, 1))
     return 1;
 
+	if (cfgfile_intval (option, value, "key_for_quit", &p->key_for_quit, 1))
+    return 1;
 
+	if (cfgfile_intval (option, value, "button_for_menu", &p->button_for_menu, 1))
+    return 1;
+
+	if (cfgfile_intval (option, value, "button_for_quit", &p->button_for_quit, 1))
+    return 1;
 	
 	if (_tcscmp (option, _T("gfx_width_windowed")) == 0) {
 		if (!_tcscmp (value, _T("native"))) {
@@ -3312,6 +3322,9 @@ void default_prefs (struct uae_prefs *p, int type)
   p->input_tablet = TABLET_OFF;
 
   p->key_for_menu = SDLK_F12;
+	p->key_for_quit = 0;
+	p->button_for_menu = -1;
+	p->button_for_quit = -1;
 
 	inputdevice_default_prefs (p);
 	blkdev_default_prefs (p);

--- a/src/include/options.h
+++ b/src/include/options.h
@@ -240,6 +240,9 @@ struct uae_prefs {
   int pandora_customControls;
 
   int key_for_menu;
+  int key_for_quit;
+  int button_for_menu;
+  int button_for_quit;
 
   /* input */
 

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -5382,6 +5382,11 @@ void inputdevice_copyconfig (const struct uae_prefs *src, struct uae_prefs *dst)
   dst->pandora_tapDelay = src->pandora_tapDelay;
   dst->pandora_customControls = src->pandora_customControls;
   
+  dst->key_for_menu = src->key_for_menu;
+  dst->key_for_quit = src->key_for_quit;
+  dst->button_for_menu = src->button_for_menu;
+  dst->button_for_quit = src->button_for_quit;
+
 	copyjport (src, dst, 0);
 	copyjport (src, dst, 1);
 	copyjport (src, dst, 2);

--- a/src/od-pandora/gui/PanelInput.cpp
+++ b/src/od-pandora/gui/PanelInput.cpp
@@ -116,11 +116,11 @@ static const int ControlKey_SDLKeyValues[] = { 0, SDLK_F11, SDLK_F12 };
 
 const char *ControlKeyValues[] = { "------------------", "F11", "F12" };
 StringListModel ControlKeyList(ControlKeyValues, 3);
-int ControlKey_SDLKeyValues_Length = sizeof(ControlKey_SDLKeyValues) / sizeof(int);
 
 static int GetControlKeyIndex(int key)
 {
-	for (int i = 0; i < (ControlKey_SDLKeyValues_Length + 1); ++i)
+	int ControlKey_SDLKeyValues_Length = sizeof(ControlKey_SDLKeyValues) / sizeof(int);
+    for (int i = 0; i < (ControlKey_SDLKeyValues_Length + 1); ++i)
 	{
 		if (ControlKey_SDLKeyValues[i] == key)
 			return i;
@@ -132,11 +132,11 @@ static const int ControlButton_SDLButtonValues[] = { -1, 0, 1, 2, 3 };
 
 const char *ControlButtonValues[] = { "------------------", "JoyButton0", "JoyButton1", "JoyButton2", "JoyButton3" };
 StringListModel ControlButtonList(ControlButtonValues, 5);
-int ControlButton_SDLButtonValues_Length = sizeof(ControlButton_SDLButtonValues) / sizeof(int);
 
 static int GetControlButtonIndex(int button)
 {
-	for (int i = 0; i < (ControlKey_SDLKeyValues_Length + 1); ++i)
+	int ControlButton_SDLButtonValues_Length = sizeof(ControlButton_SDLButtonValues) / sizeof(int);
+    for (int i = 0; i < (ControlButton_SDLButtonValues_Length + 1); ++i)
 	{
 		if (ControlButton_SDLButtonValues[i] == button)
 			return i;
@@ -510,40 +510,40 @@ void InitPanelInput(const struct _ConfigCategory& category)
     cboRight->setId("cboRight");
     cboRight->addActionListener(inputActionListener);
 
-    lblKeyForMenu = new gcn::Label("Key for Menu:");
+    lblKeyForMenu = new gcn::Label("Menu Key:");
     lblKeyForMenu->setSize(100, LABEL_HEIGHT);
     lblKeyForMenu->setAlignment(gcn::Graphics::RIGHT);
     KeyForMenu = new gcn::UaeDropDown(&ControlKeyList);
     KeyForMenu->setSize(150, DROPDOWN_HEIGHT);
     KeyForMenu->setBaseColor(gui_baseCol);
-    KeyForMenu->setId("CKeyMenu");
+    KeyForMenu->setId("KeyForMenu");
     KeyForMenu->addActionListener(inputActionListener);
 
-    lblKeyForQuit = new gcn::Label("Key for Quit:");
+    lblKeyForQuit = new gcn::Label("Quit Key:");
 	lblKeyForQuit->setSize(100, LABEL_HEIGHT);
 	lblKeyForQuit->setAlignment(gcn::Graphics::RIGHT);
 	KeyForQuit = new gcn::UaeDropDown(&ControlKeyList);
 	KeyForQuit->setSize(150, DROPDOWN_HEIGHT);
 	KeyForQuit->setBaseColor(gui_baseCol);
-	KeyForQuit->setId("CKeyMenu");
+	KeyForQuit->setId("KeyForQuit");
 	KeyForQuit->addActionListener(inputActionListener);
 
-    lblButtonForMenu= new gcn::Label("Button for Menu:");
+    lblButtonForMenu= new gcn::Label("Menu Button:");
 	lblButtonForMenu->setSize(100, LABEL_HEIGHT);
 	lblButtonForMenu->setAlignment(gcn::Graphics::RIGHT);
 	ButtonForMenu = new gcn::UaeDropDown(&ControlButtonList);
 	ButtonForMenu->setSize(150, DROPDOWN_HEIGHT);
 	ButtonForMenu->setBaseColor(gui_baseCol);
-	ButtonForMenu->setId("CKeyMenu");
+	ButtonForMenu->setId("ButtonForMenu");
 	ButtonForMenu->addActionListener(inputActionListener);
 
-	lblButtonForQuit = new gcn::Label("Button for Quit:");
+	lblButtonForQuit = new gcn::Label("Quit Button:");
 	lblButtonForQuit->setSize(100, LABEL_HEIGHT);
 	lblButtonForQuit->setAlignment(gcn::Graphics::RIGHT);
 	ButtonForQuit = new gcn::UaeDropDown(&ControlButtonList);
 	ButtonForQuit->setSize(150, DROPDOWN_HEIGHT);
 	ButtonForQuit->setBaseColor(gui_baseCol);
-	ButtonForQuit->setId("CKeyMenu");
+	ButtonForQuit->setId("ButtonForQuit");
 	ButtonForQuit->addActionListener(inputActionListener);
 
     int posY = DISTANCE_BORDER;
@@ -603,7 +603,7 @@ void InitPanelInput(const struct _ConfigCategory& category)
     posY += KeyForMenu->getHeight() + 4;
 
     category.panel->add(lblButtonForMenu, DISTANCE_BORDER, posY);
-	category.panel->add(ButtonForMenu, DISTANCE_BORDER + lblButtonForQuit->getWidth() + 8, posY);
+	category.panel->add(ButtonForMenu, DISTANCE_BORDER + lblButtonForMenu->getWidth() + 8, posY);
     category.panel->add(lblButtonForQuit, 300, posY);
 	category.panel->add(ButtonForQuit, 300 + lblButtonForQuit->getWidth() + 8, posY);
 

--- a/src/od-pandora/gui/PanelInput.cpp
+++ b/src/od-pandora/gui/PanelInput.cpp
@@ -63,6 +63,12 @@ static gcn::Label *lblRight;
 static gcn::UaeDropDown* cboRight;
 static gcn::Label *lblKeyForMenu;
 static gcn::UaeDropDown* KeyForMenu;
+static gcn::Label *lblButtonForMenu;
+static gcn::UaeDropDown* ButtonForMenu;
+static gcn::Label *lblKeyForQuit;
+static gcn::UaeDropDown* KeyForQuit;
+static gcn::Label *lblButtonForQuit;
+static gcn::UaeDropDown* ButtonForQuit;
 
 
 class StringListModel : public gcn::ListModel
@@ -106,10 +112,37 @@ const char *tapDelayValues[] = { "Normal", "Short", "None" };
 StringListModel tapDelayList(tapDelayValues, 3);
 #endif
 
-static const int ControlKey_SDLKeyValues[] = { SDLK_F11, SDLK_F12, SDL_JOYBUTTONDOWN };
+static const int ControlKey_SDLKeyValues[] = { 0, SDLK_F11, SDLK_F12 };
 
-const char *ControlKeyValues[] = { "F11", "F12", "JoyButton1" };
+const char *ControlKeyValues[] = { "------------------", "F11", "F12" };
 StringListModel ControlKeyList(ControlKeyValues, 3);
+int ControlKey_SDLKeyValues_Length = sizeof(ControlKey_SDLKeyValues) / sizeof(int);
+
+static int GetControlKeyIndex(int key)
+{
+	for (int i = 0; i < (ControlKey_SDLKeyValues_Length + 1); ++i)
+	{
+		if (ControlKey_SDLKeyValues[i] == key)
+			return i;
+	}
+	return 0; // Default: no key
+}
+
+static const int ControlButton_SDLButtonValues[] = { -1, 0, 1, 2, 3 };
+
+const char *ControlButtonValues[] = { "------------------", "JoyButton0", "JoyButton1", "JoyButton2", "JoyButton3" };
+StringListModel ControlButtonList(ControlButtonValues, 5);
+int ControlButton_SDLButtonValues_Length = sizeof(ControlButton_SDLButtonValues) / sizeof(int);
+
+static int GetControlButtonIndex(int button)
+{
+	for (int i = 0; i < (ControlKey_SDLKeyValues_Length + 1); ++i)
+	{
+		if (ControlButton_SDLButtonValues[i] == button)
+			return i;
+	}
+	return 0; // Default: no key
+}
 
 const char *mappingValues[] =
 {
@@ -301,7 +334,16 @@ public:
             customControlMap[VK_RIGHT] = amigaKey[cboRight->getSelected()];
 
         else if (actionEvent.getSource() == KeyForMenu)
-            changed_prefs.key_for_menu = ControlKey_SDLKeyValues[KeyForMenu->getSelected()] ;
+            changed_prefs.key_for_menu = ControlKey_SDLKeyValues[KeyForMenu->getSelected()];
+        
+        else if (actionEvent.getSource() == KeyForQuit)
+            changed_prefs.key_for_quit = ControlKey_SDLKeyValues[KeyForQuit->getSelected()];
+
+        else if (actionEvent.getSource() == ButtonForMenu)
+            changed_prefs.button_for_menu = ControlButton_SDLButtonValues[ButtonForMenu->getSelected()];
+        
+        else if (actionEvent.getSource() == ButtonForQuit)
+            changed_prefs.button_for_quit = ControlButton_SDLButtonValues[ButtonForQuit->getSelected()];
 
     }
 };
@@ -477,6 +519,33 @@ void InitPanelInput(const struct _ConfigCategory& category)
     KeyForMenu->setId("CKeyMenu");
     KeyForMenu->addActionListener(inputActionListener);
 
+    lblKeyForQuit = new gcn::Label("Key for Quit:");
+	lblKeyForQuit->setSize(100, LABEL_HEIGHT);
+	lblKeyForQuit->setAlignment(gcn::Graphics::RIGHT);
+	KeyForQuit = new gcn::UaeDropDown(&ControlKeyList);
+	KeyForQuit->setSize(150, DROPDOWN_HEIGHT);
+	KeyForQuit->setBaseColor(gui_baseCol);
+	KeyForQuit->setId("CKeyMenu");
+	KeyForQuit->addActionListener(inputActionListener);
+
+    lblButtonForMenu= new gcn::Label("Button for Menu:");
+	lblButtonForMenu->setSize(100, LABEL_HEIGHT);
+	lblButtonForMenu->setAlignment(gcn::Graphics::RIGHT);
+	ButtonForMenu = new gcn::UaeDropDown(&ControlButtonList);
+	ButtonForMenu->setSize(150, DROPDOWN_HEIGHT);
+	ButtonForMenu->setBaseColor(gui_baseCol);
+	ButtonForMenu->setId("CKeyMenu");
+	ButtonForMenu->addActionListener(inputActionListener);
+
+	lblButtonForQuit = new gcn::Label("Button for Quit:");
+	lblButtonForQuit->setSize(100, LABEL_HEIGHT);
+	lblButtonForQuit->setAlignment(gcn::Graphics::RIGHT);
+	ButtonForQuit = new gcn::UaeDropDown(&ControlButtonList);
+	ButtonForQuit->setSize(150, DROPDOWN_HEIGHT);
+	ButtonForQuit->setBaseColor(gui_baseCol);
+	ButtonForQuit->setId("CKeyMenu");
+	ButtonForQuit->addActionListener(inputActionListener);
+
     int posY = DISTANCE_BORDER;
     category.panel->add(lblPort0, DISTANCE_BORDER, posY);
     category.panel->add(cboPort0, DISTANCE_BORDER + lblPort0->getWidth() + 8, posY);
@@ -529,7 +598,14 @@ void InitPanelInput(const struct _ConfigCategory& category)
 
     category.panel->add(lblKeyForMenu, DISTANCE_BORDER, posY);
     category.panel->add(KeyForMenu, DISTANCE_BORDER + lblLeft->getWidth() + 8, posY);
+	category.panel->add(lblKeyForQuit, 300, posY);
+	category.panel->add(KeyForQuit, 300 + lblKeyForQuit->getWidth() + 8, posY);
     posY += KeyForMenu->getHeight() + 4;
+
+    category.panel->add(lblButtonForMenu, DISTANCE_BORDER, posY);
+	category.panel->add(ButtonForMenu, DISTANCE_BORDER + lblButtonForQuit->getWidth() + 8, posY);
+    category.panel->add(lblButtonForQuit, 300, posY);
+	category.panel->add(ButtonForQuit, 300 + lblButtonForQuit->getWidth() + 8, posY);
 
     RefreshPanelInput();
 }
@@ -576,6 +652,12 @@ void ExitPanelInput(void)
 
     delete lblKeyForMenu;
     delete KeyForMenu;
+	delete lblKeyForQuit;
+	delete KeyForQuit;
+    delete lblButtonForMenu;
+    delete ButtonForMenu;
+    delete lblButtonForQuit;
+	delete ButtonForQuit;
 
     delete inputActionListener;
 }
@@ -671,12 +753,8 @@ void RefreshPanelInput(void)
     cboLeft->setSelected(GetAmigaKeyIndex(customControlMap[VK_LEFT]));
     cboRight->setSelected(GetAmigaKeyIndex(customControlMap[VK_RIGHT]));
 
-    for(i=0; i<4; ++i)
-    {
-        if(changed_prefs.key_for_menu == ControlKey_SDLKeyValues[i])
-        {
-            KeyForMenu->setSelected(i);
-            break;
-        }
-    }
+	KeyForMenu->setSelected(GetControlKeyIndex(changed_prefs.key_for_menu));
+	KeyForQuit->setSelected(GetControlKeyIndex(changed_prefs.key_for_quit));
+    ButtonForMenu->setSelected(GetControlButtonIndex(changed_prefs.button_for_menu));
+	ButtonForQuit->setSelected(GetControlButtonIndex(changed_prefs.button_for_quit));
 }

--- a/src/od-pandora/pandora.cpp
+++ b/src/od-pandora/pandora.cpp
@@ -884,13 +884,17 @@ int handle_msgpump(void)
 			break;
 
 		case SDL_JOYBUTTONDOWN:
-			if (currprefs.key_for_menu == SDL_JOYBUTTONDOWN && rEvent.jbutton.button == 1)
+			if (rEvent.jbutton.button == currprefs.button_for_menu)
 				inputdevice_add_inputcode(AKS_ENTERGUI, 1);
+			if (rEvent.jbutton.button == currprefs.button_for_quit)
+				inputdevice_add_inputcode(AKS_QUIT, 1);
 			break;
 	        
 		case SDL_KEYDOWN:
 			if (rEvent.key.keysym.sym == currprefs.key_for_menu)
 				inputdevice_add_inputcode(AKS_ENTERGUI, 1);
+			if (rEvent.key.keysym.sym == currprefs.key_for_quit)
+				inputdevice_add_inputcode(AKS_QUIT, 1);
 			
 			switch (rEvent.key.keysym.sym)
 			{


### PR DESCRIPTION
Here are my modifications to allow the use of Joystick buttons to enter the menu and exit the emulator.

I have separated out the Key for Menu/Quit from Joystick Button Menu/Quit to make it easier to handle the options in the handle_msgpump method, i.e. we don't have to worry about clashing int values between SDLK and jbutton.button.